### PR TITLE
(Draft)Closes #3 Database redesign

### DIFF
--- a/server/messenger_backend/models/conversation.py
+++ b/server/messenger_backend/models/conversation.py
@@ -7,22 +7,15 @@ from .user import User
 
 class Conversation(utils.CustomModel):
 
-    user1 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user1Id", related_name="+"
-    )
-    user2 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user2Id", related_name="+", 
-    )
+    title = models.CharField(null=True, max_length=255)
+    members = models.ManyToManyField(User, db_column="members")
     createdAt = models.DateTimeField(auto_now_add=True, db_index=True)
     updatedAt = models.DateTimeField(auto_now=True)
 
-    # find conversation given two user Ids
-    def find_conversation(user1Id, user2Id):
+    # find conversation given id
+    def find_conversation(id):
         # return conversation or None if it doesn't exist
         try:
-            return Conversation.objects.get(
-                (Q(user1__id=user1Id) | Q(user1__id=user2Id)),
-                (Q(user2__id=user1Id) | Q(user2__id=user2Id)),
-            )
+            return Conversation.objects.get(Q(id=id))
         except Conversation.DoesNotExist:
             return None

--- a/server/messenger_backend/seed.py
+++ b/server/messenger_backend/seed.py
@@ -26,16 +26,19 @@ def seed():
 
     santiago.save()
 
-    santiagoConvo = Conversation(user1=thomas, user2=santiago)
+    santiagoConvo = Conversation(title="test1")
     santiagoConvo.save()
+    santiagoConvo.members.add(santiago.id)
+    santiagoConvo.members.add(thomas.id)
+
 
     messages = Message(
-        conversation=santiagoConvo, senderId=santiago.id, text="Where are you from?"
+        conversation=santiagoConvo, senderId=santiago.id, text="Where are you from?", read=False
     )
     messages.save()
 
     messages = Message(
-        conversation=santiagoConvo, senderId=thomas.id, text="I'm from New York"
+        conversation=santiagoConvo, senderId=thomas.id, text="I'm from New York", read=False
     )
     messages.save()
 
@@ -43,6 +46,7 @@ def seed():
         conversation=santiagoConvo,
         senderId=santiago.id,
         text="Share photo of your city, please",
+        read=False
     )
     messages.save()
 
@@ -54,8 +58,11 @@ def seed():
     )
     chiumbo.save()
 
-    chiumboConvo = Conversation(user1=chiumbo, user2=thomas)
+    chiumboConvo = Conversation(title="test2")
     chiumboConvo.save()
+    chiumboConvo.members.add(santiago.id)
+    chiumboConvo.members.add(chiumbo.id)
+    
 
     messages = Message(
         conversation=chiumboConvo, senderId=chiumbo.id, text="Sure! What time?"
@@ -70,8 +77,10 @@ def seed():
     )
     hualing.save()
 
-    hualingConvo = Conversation(user1=hualing, user2=thomas)
+    hualingConvo = Conversation(title="test3")
     hualingConvo.save()
+    hualingConvo.members.add(chiumbo.id)
+    hualingConvo.members.add(hualing.id)
 
     for i in range(10):
         messages = Message(


### PR DESCRIPTION
Closes #3 
Additional changes:
1. Front end - An option to create groups and adding titles and members into the same.  The title can be null in the case of private chats and in this case title would be other user's name, while n case of group chat it cannot be null. 
2. Back end - Implement Django channels for messaging in groups(this will include changes in ASGI and settings of the app too). Conversation fetching would be by ID rather than two user's IDs.  

If the app is deployed and we don't want any disruptions then, group chat can be created as another model class that will take care of group chats from now on and previous functionality will be the same, doing this we don't have to modify existing database data and functionalities.
Additionally, if we have containerized app, then for zero downtime we can set maxUnavailble optional field to zero in the Kubernetes configurations file to have our pods always up while rolling an update.
